### PR TITLE
fix the error of `Maximum function nesting level`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - 'if [ $(phpenv version-name) == "5.5" ]; then rm ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini; fi'
   - 'if [ $(phpenv version-name) != "hhvm" ] && [ $(phpenv version-name) != "nightly" ]; then echo "xdebug.overload_var_dump = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
   - 'if { [ $(phpenv version-name) == "7.2" ] || [ $(phpenv version-name) == "7.3" ]; } && [ -v COMPOSER_OPTS ]; then composer require --dev phpunit/phpunit "^5.7.11"; fi'
+  - php -m | grep xdebug
   - composer --version
   - travis_retry composer update $COMPOSER_OPTS --no-interaction --prefer-source
 

--- a/src/Tea.php
+++ b/src/Tea.php
@@ -75,11 +75,10 @@ class Tea
             $stack = self::$config['handler'];
         } else {
             $stack = HandlerStack::create();
+            $stack->push(Middleware::mapResponse(static function (ResponseInterface $response) {
+                return new Response($response);
+            }));
         }
-
-        $stack->push(Middleware::mapResponse(static function (ResponseInterface $response) {
-            return new Response($response);
-        }));
 
         self::$config['handler'] = $stack;
 

--- a/tests/Unit/TeaTest.php
+++ b/tests/Unit/TeaTest.php
@@ -3,6 +3,7 @@
 namespace AlibabaCloud\Tea\Tests\Unit;
 
 use AlibabaCloud\Tea\Exception\TeaError;
+use AlibabaCloud\Tea\Request;
 use AlibabaCloud\Tea\Tea;
 use PHPUnit\Framework\TestCase;
 
@@ -76,5 +77,22 @@ class TeaTest extends TestCase
             null,
             ['c' => 3]
         ));
+    }
+
+    public static function testRequest()
+    {
+        ini_set('xdebug.max_nesting_level', 100);
+        $count = 102;
+        while ($count > 0) {
+            $request                  = new Request();
+            $request->method          = 'GET';
+            $request->protocol        = 'http';
+            $request->headers['host'] = 'example.com';
+            $request->port            = 80;
+            Tea::send($request);
+            --$count;
+        }
+        // No Exception is OK
+        self::assertTrue(true);
     }
 }


### PR DESCRIPTION
The `Maximum function nesting level of '100' reached, aborting!` error occurs when the user keeps requesting the API server repeatedly.

Because there are multiple layers of nesting in `Middleware::mapResponse` that shouldn't be there, as the number of requests increases, the number of layers of nesting increases as well, eventually causing the program to throw an exception.