### PR TITLE
fix: treat Dara::sleep argument as milliseconds

### DIFF
--- a/src/Dara.php
+++ b/src/Dara.php
@@ -216,9 +216,27 @@ class Dara
         return $backOffTime;
     }
 
+    /**
+     * Sleep for the given duration in milliseconds.
+     * Aligns with getBackoffDelay() which returns milliseconds.
+     *
+     * @param int $time duration in milliseconds
+     */
     public static function sleep($time)
     {
-        sleep($time);
+        $ms = (int) $time;
+        if ($ms <= 0) {
+            return;
+        }
+        // usleep() may not support >1s on some platforms; split into sleep + usleep
+        $seconds = (int) ($ms / 1000);
+        $micros = ($ms % 1000) * 1000;
+        if ($seconds > 0) {
+            sleep($seconds);
+        }
+        if ($micros > 0) {
+            usleep($micros);
+        }
     }
 
     public static function isRetryable($retry, $retryTimes = 0)

--- a/tests/Unit/DaraTest.php
+++ b/tests/Unit/DaraTest.php
@@ -67,11 +67,13 @@ class DaraTest extends TestCase
 
     public static function testSleep()
     {
-        $before = time();
-        Dara::sleep(1);
-        $after = time();
+        $before = microtime(true);
+        Dara::sleep(1000); // 1000ms = 1s
+        $after = microtime(true);
+        $elapsed = $after - $before;
 
-        self::assertTrue($after - $before >= 1);
+        self::assertTrue($elapsed >= 1.0);
+        self::assertTrue($elapsed < 2.0);
     }
 
     public static function testIsRetryable()


### PR DESCRIPTION
## Summary
- `Dara::sleep` now interprets its argument as milliseconds (aligned with `getBackoffDelay` / Go `dara.Sleep`), using `sleep`+`usleep` for portability on long delays.
- Update `testSleep` to assert ~1s for `sleep(1000)` and prevent second-vs-ms regression.