### PR TITLE
fix: align getBackoffDelay exception matching with shouldRetry

### DIFF
--- a/src/Dara.php
+++ b/src/Dara.php
@@ -282,13 +282,12 @@ class Dara
      */
     public static function getBackoffDelay($options, $ctx) {
         $ex = $ctx->getException();
-        $fullClassName = get_class($ex);
-        $classNameParts = explode('\\', $fullClassName);
-        $className = end($classNameParts);
+        // Match exception by logical name (same as shouldRetry), not PHP class basename.
+        // e.g. DaraRespException::getName() => 'ResponseError'
         $conditions = $options->getRetryCondition();
         foreach ($conditions as $condition) {
 
-            if (!in_array($className, $condition->getException()) && !in_array($ex->getErrCode(), $condition->getErrorCode())) {
+            if (!in_array($ex->getName(), $condition->getException()) && !in_array($ex->getErrCode(), $condition->getErrorCode())) {
                 continue;
             }
     

--- a/tests/Unit/RetryTest.php
+++ b/tests/Unit/RetryTest.php
@@ -465,5 +465,50 @@ class RetryTest extends TestCase
         $backoffTime = Dara::getBackoffDelay($options, $context);
         $this->assertEquals($backoffTime, 1000);
     }
+
+    /**
+     * shouldRetry and getBackoffDelay must use the same exception identity field
+     * (logical name from getName(), e.g. ResponseError), not PHP class basename.
+     */
+    public function testShouldRetryAndGetBackoffDelayUseSameExceptionName()
+    {
+        $fixedPolicy = BackoffPolicy::newBackoffPolicy([
+            'policy' => 'Fixed',
+            'period' => 2000,
+        ]);
+        $condition = new RetryCondition([
+            'maxAttempts' => 3,
+            'exception' => ['ResponseError'],
+            'backoff' => $fixedPolicy,
+        ]);
+        $options = new RetryOptions([
+            'retryable' => true,
+            'retryCondition' => [$condition],
+        ]);
+        $context = new RetryPolicyContext([
+            'retriesAttempted' => 1,
+            'exception' => new DaraRespException([
+                'errCode' => 'Throttling',
+                'message' => 'throttled',
+            ]),
+        ]);
+
+        $this->assertEquals('ResponseError', $context->getException()->getName());
+        $this->assertTrue(Dara::shouldRetry($options, $context));
+        $this->assertEquals(2000, Dara::getBackoffDelay($options, $context));
+
+        // Class basename must not be required; config keyed by PHP class would miss shouldRetry.
+        $classNameCondition = new RetryCondition([
+            'maxAttempts' => 3,
+            'exception' => ['DaraRespException'],
+            'backoff' => $fixedPolicy,
+        ]);
+        $classNameOptions = new RetryOptions([
+            'retryable' => true,
+            'retryCondition' => [$classNameCondition],
+        ]);
+        $this->assertFalse(Dara::shouldRetry($classNameOptions, $context));
+        $this->assertEquals(100, Dara::getBackoffDelay($classNameOptions, $context));
+    }
 }
 


### PR DESCRIPTION
## Summary
- Align `getBackoffDelay` exception matching with `shouldRetry` by using `$ex->getName()` (business name such as `ResponseError`) instead of PHP class basename.
- Add unit coverage so the same exception/config hits both retry decision and backoff delay.